### PR TITLE
Add root/docs static preview assets and serve `public` static files

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TrueSign | Transfer Intelligence</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main>
+      <aside class="sidebar">
+        <div class="brand">TrueSign</div>
+        <nav class="nav">
+          <a class="active" href="#">Transfer View</a>
+          <a href="#">Market Radar</a>
+          <a href="#">Squad Planner</a>
+          <a href="#">Contract Risk</a>
+          <a href="#">Negotiation Desk</a>
+        </nav>
+      </aside>
+      <section class="content">
+        <div class="container">
+          <header class="page-header">
+            <div>
+              <h1 class="page-title">Transfer Intelligence</h1>
+              <p class="page-subtitle">Shortlist view for priority targets · Summer Window</p>
+            </div>
+            <div class="page-actions">
+              <span class="action-label">Filters</span>
+              <button class="action-pill" type="button">Position · CM</button>
+              <button class="action-pill" type="button">Age · 18–24</button>
+              <button class="action-pill" type="button">League · Top 5</button>
+            </div>
+          </header>
+
+          <section class="section">
+            <div class="primary-data">
+              <div class="data-block">
+                <span class="data-label">Expected Contribution</span>
+                <div class="data-value">+9.4%</div>
+                <div class="data-support">Projected points uplift over 36 matches</div>
+              </div>
+              <div class="data-block">
+                <span class="data-label">Target Valuation</span>
+                <div class="data-value">€42.6m</div>
+                <div class="data-support">Model range €39.1m – €45.8m</div>
+              </div>
+              <div class="data-block">
+                <span class="data-label">Contract Leverage</span>
+                <div class="data-value">68</div>
+                <div class="data-support">Measured against squad replacement cost</div>
+              </div>
+              <div class="data-block">
+                <span class="data-label">ROI Horizon</span>
+                <div class="data-value positive">+1.8x</div>
+                <div class="data-support">24-month performance return</div>
+              </div>
+            </div>
+          </section>
+
+          <section class="section alt">
+            <div>
+              <h2 class="section-title">Analytical Breakdown</h2>
+              <p class="section-subtitle">Performance profile and negotiation leverage</p>
+            </div>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>Club</th>
+                  <th class="num">Index</th>
+                  <th class="num">Ball Progression</th>
+                  <th class="num">Defensive Value</th>
+                  <th class="num">Contract Risk</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><strong>Rafael Mendes</strong></td>
+                  <td>Benfica</td>
+                  <td class="num"><strong>92</strong></td>
+                  <td class="num">+18%</td>
+                  <td class="num">+12%</td>
+                  <td class="num">Low</td>
+                </tr>
+                <tr>
+                  <td><strong>Ivan Stojan</strong></td>
+                  <td>Atalanta</td>
+                  <td class="num"><strong>88</strong></td>
+                  <td class="num">+14%</td>
+                  <td class="num">+10%</td>
+                  <td class="num">Medium</td>
+                </tr>
+                <tr>
+                  <td><strong>Tomas Silva</strong></td>
+                  <td>Sporting</td>
+                  <td class="num"><strong>85</strong></td>
+                  <td class="num">+11%</td>
+                  <td class="num">+9%</td>
+                  <td class="num">Medium</td>
+                </tr>
+                <tr>
+                  <td><strong>Jules Martin</strong></td>
+                  <td>Lille</td>
+                  <td class="num"><strong>83</strong></td>
+                  <td class="num">+9%</td>
+                  <td class="num">+8%</td>
+                  <td class="num">High</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section class="section context">
+            <div>
+              <h2 class="section-title">Context & Supporting Signals</h2>
+              <p class="section-subtitle">Secondary indicators used to validate the shortlist</p>
+            </div>
+            <div class="context-grid">
+              <div class="context-item">
+                <span>Workload Reliability</span>
+                <p>Rafael Mendes and Ivan Stojan remain within optimal load thresholds over 18 weeks.</p>
+              </div>
+              <div class="context-item">
+                <span>Medical Flagging</span>
+                <p>No recurring muscle injuries flagged in the past 14 months across the cohort.</p>
+              </div>
+              <div class="context-item">
+                <span>Negotiation Window</span>
+                <p>Two targets enter contract years in 10 months; leverage improves after January.</p>
+              </div>
+              <div class="context-item">
+                <span>Squad Fit Confidence</span>
+                <p>Projected tactical compatibility remains above 0.72 across current manager profile.</p>
+              </div>
+            </div>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Signal</th>
+                  <th>Source</th>
+                  <th class="num">Confidence</th>
+                  <th class="num">Δ Last 90 Days</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><strong>Training Adaptation</strong></td>
+                  <td>Performance Lab</td>
+                  <td class="num"><strong>0.82</strong></td>
+                  <td class="num">+0.04</td>
+                </tr>
+                <tr>
+                  <td><strong>Agent Alignment</strong></td>
+                  <td>Negotiation Desk</td>
+                  <td class="num"><strong>0.76</strong></td>
+                  <td class="num">+0.02</td>
+                </tr>
+                <tr>
+                  <td><strong>Fan Sentiment Risk</strong></td>
+                  <td>Comms Desk</td>
+                  <td class="num"><strong>0.69</strong></td>
+                  <td class="num">-0.01</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,309 @@
+:root {
+  color-scheme: only light;
+  --bg-main: #f8fafc;
+  --bg-section: #ffffff;
+  --border-hairline: #e5eaf1;
+  --text-main: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #94a3b8;
+  --brand-blue: #2563eb;
+  --brand-green: #16a34a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: var(--bg-main);
+  color: var(--text-main);
+}
+
+main {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: var(--bg-section);
+  border-right: 1px solid var(--border-hairline);
+  padding: 24px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.brand {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-main);
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.nav a {
+  text-decoration: none;
+  color: var(--text-secondary);
+  font-size: 14px;
+  padding: 10px 12px 10px 10px;
+  border-left: 2px solid transparent;
+  transition: background 120ms ease-out, color 120ms ease-out, border-color 120ms ease-out;
+}
+
+.nav a:hover {
+  background: #f1f5f9;
+  color: var(--text-main);
+}
+
+.nav a.active {
+  background: #eef2ff;
+  color: var(--text-main);
+  border-left-color: var(--brand-blue);
+}
+
+.content {
+  padding: 40px 32px 80px;
+}
+
+.container {
+  max-width: 1280px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.page-title {
+  font-size: 30px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.page-subtitle {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.page-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.action-label {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.action-pill {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 6px 10px;
+  border: 1px solid var(--border-hairline);
+  color: var(--text-secondary);
+  background: var(--bg-section);
+  transition: border-color 120ms ease-out, color 120ms ease-out;
+}
+
+.action-pill:hover {
+  border-color: var(--brand-blue);
+  color: var(--text-main);
+}
+
+.primary-data {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.data-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.data-label {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.data-value {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.data-value.positive {
+  color: var(--brand-green);
+}
+
+.data-support {
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section.alt {
+  background: var(--bg-section);
+  padding: 32px;
+  border-top: 1px solid var(--border-hairline);
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.section-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.section-subtitle {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table thead th {
+  text-align: left;
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  background: #f1f5f9;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.table tbody tr {
+  height: 44px;
+  transition: background 120ms ease-out;
+}
+
+.table tbody tr:hover {
+  background: #f8fafc;
+}
+
+.table tbody td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-hairline);
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.table tbody td strong {
+  color: var(--text-main);
+  font-weight: 600;
+}
+
+.table .num {
+  text-align: right;
+  color: var(--text-main);
+}
+
+.section.context {
+  gap: 24px;
+}
+
+.context-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.context-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.context-item p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.context-item span {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+@media (max-width: 1024px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .primary-data {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .context-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .content {
+    padding: 24px 20px 56px;
+  }
+
+  .page-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .primary-data {
+    grid-template-columns: 1fr;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TrueSign | Transfer Intelligence</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main>
+      <aside class="sidebar">
+        <div class="brand">TrueSign</div>
+        <nav class="nav">
+          <a class="active" href="#">Transfer View</a>
+          <a href="#">Market Radar</a>
+          <a href="#">Squad Planner</a>
+          <a href="#">Contract Risk</a>
+          <a href="#">Negotiation Desk</a>
+        </nav>
+      </aside>
+      <section class="content">
+        <div class="container">
+          <header class="page-header">
+            <div>
+              <h1 class="page-title">Transfer Intelligence</h1>
+              <p class="page-subtitle">Shortlist view for priority targets · Summer Window</p>
+            </div>
+            <div class="page-actions">
+              <span class="action-label">Filters</span>
+              <button class="action-pill" type="button">Position · CM</button>
+              <button class="action-pill" type="button">Age · 18–24</button>
+              <button class="action-pill" type="button">League · Top 5</button>
+            </div>
+          </header>
+
+          <section class="section">
+            <div class="primary-data">
+              <div class="data-block">
+                <span class="data-label">Expected Contribution</span>
+                <div class="data-value">+9.4%</div>
+                <div class="data-support">Projected points uplift over 36 matches</div>
+              </div>
+              <div class="data-block">
+                <span class="data-label">Target Valuation</span>
+                <div class="data-value">€42.6m</div>
+                <div class="data-support">Model range €39.1m – €45.8m</div>
+              </div>
+              <div class="data-block">
+                <span class="data-label">Contract Leverage</span>
+                <div class="data-value">68</div>
+                <div class="data-support">Measured against squad replacement cost</div>
+              </div>
+              <div class="data-block">
+                <span class="data-label">ROI Horizon</span>
+                <div class="data-value positive">+1.8x</div>
+                <div class="data-support">24-month performance return</div>
+              </div>
+            </div>
+          </section>
+
+          <section class="section alt">
+            <div>
+              <h2 class="section-title">Analytical Breakdown</h2>
+              <p class="section-subtitle">Performance profile and negotiation leverage</p>
+            </div>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>Club</th>
+                  <th class="num">Index</th>
+                  <th class="num">Ball Progression</th>
+                  <th class="num">Defensive Value</th>
+                  <th class="num">Contract Risk</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><strong>Rafael Mendes</strong></td>
+                  <td>Benfica</td>
+                  <td class="num"><strong>92</strong></td>
+                  <td class="num">+18%</td>
+                  <td class="num">+12%</td>
+                  <td class="num">Low</td>
+                </tr>
+                <tr>
+                  <td><strong>Ivan Stojan</strong></td>
+                  <td>Atalanta</td>
+                  <td class="num"><strong>88</strong></td>
+                  <td class="num">+14%</td>
+                  <td class="num">+10%</td>
+                  <td class="num">Medium</td>
+                </tr>
+                <tr>
+                  <td><strong>Tomas Silva</strong></td>
+                  <td>Sporting</td>
+                  <td class="num"><strong>85</strong></td>
+                  <td class="num">+11%</td>
+                  <td class="num">+9%</td>
+                  <td class="num">Medium</td>
+                </tr>
+                <tr>
+                  <td><strong>Jules Martin</strong></td>
+                  <td>Lille</td>
+                  <td class="num"><strong>83</strong></td>
+                  <td class="num">+9%</td>
+                  <td class="num">+8%</td>
+                  <td class="num">High</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section class="section context">
+            <div>
+              <h2 class="section-title">Context & Supporting Signals</h2>
+              <p class="section-subtitle">Secondary indicators used to validate the shortlist</p>
+            </div>
+            <div class="context-grid">
+              <div class="context-item">
+                <span>Workload Reliability</span>
+                <p>Rafael Mendes and Ivan Stojan remain within optimal load thresholds over 18 weeks.</p>
+              </div>
+              <div class="context-item">
+                <span>Medical Flagging</span>
+                <p>No recurring muscle injuries flagged in the past 14 months across the cohort.</p>
+              </div>
+              <div class="context-item">
+                <span>Negotiation Window</span>
+                <p>Two targets enter contract years in 10 months; leverage improves after January.</p>
+              </div>
+              <div class="context-item">
+                <span>Squad Fit Confidence</span>
+                <p>Projected tactical compatibility remains above 0.72 across current manager profile.</p>
+              </div>
+            </div>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Signal</th>
+                  <th>Source</th>
+                  <th class="num">Confidence</th>
+                  <th class="num">Δ Last 90 Days</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><strong>Training Adaptation</strong></td>
+                  <td>Performance Lab</td>
+                  <td class="num"><strong>0.82</strong></td>
+                  <td class="num">+0.04</td>
+                </tr>
+                <tr>
+                  <td><strong>Agent Alignment</strong></td>
+                  <td>Negotiation Desk</td>
+                  <td class="num"><strong>0.76</strong></td>
+                  <td class="num">+0.02</td>
+                </tr>
+                <tr>
+                  <td><strong>Fan Sentiment Risk</strong></td>
+                  <td>Comms Desk</td>
+                  <td class="num"><strong>0.69</strong></td>
+                  <td class="num">-0.01</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,178 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TrueSign | Transfer Intelligence</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main>
+      <aside class="sidebar">
+        <div class="brand">TrueSign</div>
+        <nav class="nav">
+          <a class="active" href="#">Transfer View</a>
+          <a href="#">Market Radar</a>
+          <a href="#">Squad Planner</a>
+          <a href="#">Contract Risk</a>
+          <a href="#">Negotiation Desk</a>
+        </nav>
+      </aside>
+      <section class="content">
+        <div class="container">
+          <header class="page-header">
+            <div>
+              <h1 class="page-title">Transfer Intelligence</h1>
+              <p class="page-subtitle">Shortlist view for priority targets · Summer Window</p>
+            </div>
+            <div class="page-actions">
+              <span class="action-label">Filters</span>
+              <button class="action-pill" type="button">Position · CM</button>
+              <button class="action-pill" type="button">Age · 18–24</button>
+              <button class="action-pill" type="button">League · Top 5</button>
+            </div>
+          </header>
+
+          <section class="section">
+            <div class="primary-data">
+              <div class="data-block">
+                <span class="data-label">Expected Contribution</span>
+                <div class="data-value">+9.4%</div>
+                <div class="data-support">Projected points uplift over 36 matches</div>
+              </div>
+              <div class="data-block">
+                <span class="data-label">Target Valuation</span>
+                <div class="data-value">€42.6m</div>
+                <div class="data-support">Model range €39.1m – €45.8m</div>
+              </div>
+              <div class="data-block">
+                <span class="data-label">Contract Leverage</span>
+                <div class="data-value">68</div>
+                <div class="data-support">Measured against squad replacement cost</div>
+              </div>
+              <div class="data-block">
+                <span class="data-label">ROI Horizon</span>
+                <div class="data-value positive">+1.8x</div>
+                <div class="data-support">24-month performance return</div>
+              </div>
+            </div>
+          </section>
+
+          <section class="section alt">
+            <div>
+              <h2 class="section-title">Analytical Breakdown</h2>
+              <p class="section-subtitle">Performance profile and negotiation leverage</p>
+            </div>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Player</th>
+                  <th>Club</th>
+                  <th class="num">Index</th>
+                  <th class="num">Ball Progression</th>
+                  <th class="num">Defensive Value</th>
+                  <th class="num">Contract Risk</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><strong>Rafael Mendes</strong></td>
+                  <td>Benfica</td>
+                  <td class="num"><strong>92</strong></td>
+                  <td class="num">+18%</td>
+                  <td class="num">+12%</td>
+                  <td class="num">Low</td>
+                </tr>
+                <tr>
+                  <td><strong>Ivan Stojan</strong></td>
+                  <td>Atalanta</td>
+                  <td class="num"><strong>88</strong></td>
+                  <td class="num">+14%</td>
+                  <td class="num">+10%</td>
+                  <td class="num">Medium</td>
+                </tr>
+                <tr>
+                  <td><strong>Tomas Silva</strong></td>
+                  <td>Sporting</td>
+                  <td class="num"><strong>85</strong></td>
+                  <td class="num">+11%</td>
+                  <td class="num">+9%</td>
+                  <td class="num">Medium</td>
+                </tr>
+                <tr>
+                  <td><strong>Jules Martin</strong></td>
+                  <td>Lille</td>
+                  <td class="num"><strong>83</strong></td>
+                  <td class="num">+9%</td>
+                  <td class="num">+8%</td>
+                  <td class="num">High</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section class="section context">
+            <div>
+              <h2 class="section-title">Context & Supporting Signals</h2>
+              <p class="section-subtitle">Secondary indicators used to validate the shortlist</p>
+            </div>
+            <div class="context-grid">
+              <div class="context-item">
+                <span>Workload Reliability</span>
+                <p>Rafael Mendes and Ivan Stojan remain within optimal load thresholds over 18 weeks.</p>
+              </div>
+              <div class="context-item">
+                <span>Medical Flagging</span>
+                <p>No recurring muscle injuries flagged in the past 14 months across the cohort.</p>
+              </div>
+              <div class="context-item">
+                <span>Negotiation Window</span>
+                <p>Two targets enter contract years in 10 months; leverage improves after January.</p>
+              </div>
+              <div class="context-item">
+                <span>Squad Fit Confidence</span>
+                <p>Projected tactical compatibility remains above 0.72 across current manager profile.</p>
+              </div>
+            </div>
+            <table class="table">
+              <thead>
+                <tr>
+                  <th>Signal</th>
+                  <th>Source</th>
+                  <th class="num">Confidence</th>
+                  <th class="num">Δ Last 90 Days</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><strong>Training Adaptation</strong></td>
+                  <td>Performance Lab</td>
+                  <td class="num"><strong>0.82</strong></td>
+                  <td class="num">+0.04</td>
+                </tr>
+                <tr>
+                  <td><strong>Agent Alignment</strong></td>
+                  <td>Negotiation Desk</td>
+                  <td class="num"><strong>0.76</strong></td>
+                  <td class="num">+0.02</td>
+                </tr>
+                <tr>
+                  <td><strong>Fan Sentiment Risk</strong></td>
+                  <td>Comms Desk</td>
+                  <td class="num"><strong>0.69</strong></td>
+                  <td class="num">-0.01</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,309 @@
+:root {
+  color-scheme: only light;
+  --bg-main: #f8fafc;
+  --bg-section: #ffffff;
+  --border-hairline: #e5eaf1;
+  --text-main: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #94a3b8;
+  --brand-blue: #2563eb;
+  --brand-green: #16a34a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: var(--bg-main);
+  color: var(--text-main);
+}
+
+main {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: var(--bg-section);
+  border-right: 1px solid var(--border-hairline);
+  padding: 24px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.brand {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-main);
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.nav a {
+  text-decoration: none;
+  color: var(--text-secondary);
+  font-size: 14px;
+  padding: 10px 12px 10px 10px;
+  border-left: 2px solid transparent;
+  transition: background 120ms ease-out, color 120ms ease-out, border-color 120ms ease-out;
+}
+
+.nav a:hover {
+  background: #f1f5f9;
+  color: var(--text-main);
+}
+
+.nav a.active {
+  background: #eef2ff;
+  color: var(--text-main);
+  border-left-color: var(--brand-blue);
+}
+
+.content {
+  padding: 40px 32px 80px;
+}
+
+.container {
+  max-width: 1280px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.page-title {
+  font-size: 30px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.page-subtitle {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.page-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.action-label {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.action-pill {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 6px 10px;
+  border: 1px solid var(--border-hairline);
+  color: var(--text-secondary);
+  background: var(--bg-section);
+  transition: border-color 120ms ease-out, color 120ms ease-out;
+}
+
+.action-pill:hover {
+  border-color: var(--brand-blue);
+  color: var(--text-main);
+}
+
+.primary-data {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.data-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.data-label {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.data-value {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.data-value.positive {
+  color: var(--brand-green);
+}
+
+.data-support {
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section.alt {
+  background: var(--bg-section);
+  padding: 32px;
+  border-top: 1px solid var(--border-hairline);
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.section-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.section-subtitle {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table thead th {
+  text-align: left;
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  background: #f1f5f9;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.table tbody tr {
+  height: 44px;
+  transition: background 120ms ease-out;
+}
+
+.table tbody tr:hover {
+  background: #f8fafc;
+}
+
+.table tbody td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-hairline);
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.table tbody td strong {
+  color: var(--text-main);
+  font-weight: 600;
+}
+
+.table .num {
+  text-align: right;
+  color: var(--text-main);
+}
+
+.section.context {
+  gap: 24px;
+}
+
+.context-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.context-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.context-item p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.context-item span {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+@media (max-width: 1024px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .primary-data {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .context-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .content {
+    padding: 24px 20px 56px;
+  }
+
+  .page-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .primary-data {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/server.js
+++ b/src/server.js
@@ -13,6 +13,7 @@ async function bootstrap() {
   app.use(helmet());
   app.use(express.json({ limit: '1mb' }));
   app.use(cors({ origin: true }));
+  app.use(express.static('public'));
 
   app.get('/health', (_req, res) => {
     res.json({ ok: true });
@@ -49,4 +50,3 @@ bootstrap().catch((err) => {
   console.error(err);
   process.exit(1);
 });
-

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,309 @@
+:root {
+  color-scheme: only light;
+  --bg-main: #f8fafc;
+  --bg-section: #ffffff;
+  --border-hairline: #e5eaf1;
+  --text-main: #0f172a;
+  --text-secondary: #475569;
+  --text-muted: #94a3b8;
+  --brand-blue: #2563eb;
+  --brand-green: #16a34a;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, sans-serif;
+  background: var(--bg-main);
+  color: var(--text-main);
+}
+
+main {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: var(--bg-section);
+  border-right: 1px solid var(--border-hairline);
+  padding: 24px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.brand {
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-main);
+}
+
+.nav {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.nav a {
+  text-decoration: none;
+  color: var(--text-secondary);
+  font-size: 14px;
+  padding: 10px 12px 10px 10px;
+  border-left: 2px solid transparent;
+  transition: background 120ms ease-out, color 120ms ease-out, border-color 120ms ease-out;
+}
+
+.nav a:hover {
+  background: #f1f5f9;
+  color: var(--text-main);
+}
+
+.nav a.active {
+  background: #eef2ff;
+  color: var(--text-main);
+  border-left-color: var(--brand-blue);
+}
+
+.content {
+  padding: 40px 32px 80px;
+}
+
+.container {
+  max-width: 1280px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 56px;
+}
+
+.page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.page-title {
+  font-size: 30px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.page-subtitle {
+  margin: 8px 0 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+.page-actions {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.action-label {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.action-pill {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 6px 10px;
+  border: 1px solid var(--border-hairline);
+  color: var(--text-secondary);
+  background: var(--bg-section);
+  transition: border-color 120ms ease-out, color 120ms ease-out;
+}
+
+.action-pill:hover {
+  border-color: var(--brand-blue);
+  color: var(--text-main);
+}
+
+.primary-data {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.data-block {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.data-label {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.data-value {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.data-value.positive {
+  color: var(--brand-green);
+}
+
+.data-support {
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section.alt {
+  background: var(--bg-section);
+  padding: 32px;
+  border-top: 1px solid var(--border-hairline);
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.section-title {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.section-subtitle {
+  font-size: 14px;
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.table thead th {
+  text-align: left;
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  background: #f1f5f9;
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.table tbody tr {
+  height: 44px;
+  transition: background 120ms ease-out;
+}
+
+.table tbody tr:hover {
+  background: #f8fafc;
+}
+
+.table tbody td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-hairline);
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.table tbody td strong {
+  color: var(--text-main);
+  font-weight: 600;
+}
+
+.table .num {
+  text-align: right;
+  color: var(--text-main);
+}
+
+.section.context {
+  gap: 24px;
+}
+
+.context-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.context-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.context-item p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+.context-item span {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+@media (max-width: 1024px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .primary-data {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .context-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .content {
+    padding: 24px 20px 56px;
+  }
+
+  .page-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .primary-data {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a GitHub Pages–deployable static preview and allow the running API to serve the same static preview for local review.

### Description
- Add static preview HTML and CSS at `public/index.html` and `public/styles.css` and also copy them to `docs/index.html` and repository root as `index.html` and `styles.css` so Pages can serve the redesign from either `docs/` or the repository root.
- Enable serving of local static assets by adding `app.use(express.static('public'))` to `src/server.js` so the API can serve the preview during local runs.
- Stage and commit the new files (`index.html`, `styles.css`, `public/`, `docs/`) to the repository.

### Testing
- No automated tests were run for this change (static file additions and a small middleware change only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821e643e008322b165dc5047b3ae33)